### PR TITLE
Updating CodeSignatureVerifier for MSTeams.download recipe.

### DIFF
--- a/MSTeams/MSTeams.download.recipe
+++ b/MSTeams/MSTeams.download.recipe
@@ -43,15 +43,19 @@
             <string>EndOfCheckPhase</string>
         </dict>
         <dict>
-            <key>Processor</key>
-            <string>CodeSignatureVerifier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>input_path</key>
-                <string>%pathname%</string>
-                <key>requirement</key>
-                <string>identifier "com.microsoft.teams" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UBF8T346G9</string>
-            </dict>
+           <key>Processor</key>
+           <string>CodeSignatureVerifier</string>
+           <key>Arguments</key>
+           <dict>
+              <key>input_path</key>
+              <string>%pathname%</string>
+              <key>expected_authority_names</key>
+              <array>
+                 <string>Developer ID Installer: Microsoft Corporation (UBF8T346G9)</string>
+                 <string>Developer ID Certification Authority</string>
+                 <string>Apple Root CA</string>
+              </array>
+           </dict>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
The CodeSignatureVerifier values in the MSTeams.download recipe are for the Microsoft Teams app, but the download recipe now needs to be checking the downloaded installer package's code signing. 

This PR updates the MSTeams.download recipe's CodeSignatureVerifier for the installer package's code signing.