### PR TITLE
MSTeams.munki.recipe

### DIFF
--- a/MSTeams/MSTeams.munki.recipe
+++ b/MSTeams/MSTeams.munki.recipe
@@ -47,6 +47,93 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>destination_path</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/unpack</string>
+               <key>flat_pkg_path</key>
+               <string>%pathname%</string>
+            </dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>pattern</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/unpack/*Teams*.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkgroot</key>
+                <string>%RECIPE_CACHE_DIR%/downloads/Applications</string>
+                <key>pkgdirs</key>
+                <dict>
+                    <key>Applications</key>
+                    <string>0755</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PkgRootCreator</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>destination_path</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/Applications</string>
+               <key>pkg_payload_path</key>
+               <string>%found_filename%/Payload</string>
+            </dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>input_plist_path</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/Applications/Microsoft Teams.app/Contents/Info.plist</string>
+               <key>plist_version_key</key>
+               <string>CFBundleShortVersionString</string>
+            </dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%/downloads/</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/Microsoft Teams.app</string>
+                </array>
+                <key>version_comparison_key</key>
+                <string>CFBundleShortVersionString</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
@@ -57,6 +144,18 @@
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+            <key>Arguments</key>
+            <dict>
+               <key>path_list</key>
+               <array>
+                  <string>%RECIPE_CACHE_DIR%/downloads/unpack</string>
+                  <string>%RECIPE_CACHE_DIR%/downloads/Applications</string>
+               </array>
+            </dict>
+         </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
Based upon @rtrouton’s example
(https://github.com/autopkg/rtrouton-recipes/blob/master/MicrosoftTeams/
MicrosoftTeams.pkg.recipe).

The version is now being pulled from the info.plist, so creating an
installs array