### PR TITLE
fix git-lfs.pkg recipe

### DIFF
--- a/git-lfs/git-lfs.pkg.recipe
+++ b/git-lfs/git-lfs.pkg.recipe
@@ -43,7 +43,7 @@
                 <key>archive_path</key>
                 <string>%pathname%</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/usr/local/bin</string>
+                <string>%pkgroot%/usr/local/bin/%NAME%-%version%</string>
                 <key>purge_destination</key>
                 <true/>
             </dict>


### PR DESCRIPTION
The git-lfs.pkg recipe fails because it is trying to copy a file that does not exist.

```
FileMover
{'Input': {'source': u'/Cache/local.munki.git-lfs/pkgroot/usr/local/bin/git-lfs-2.5.1/git-lfs',
           'target': u'/Cache/local.munki.git-lfs/pkgroot/usr/local/bin/git-lfs'}}
[Errno 2] No such file or directory
Failed.
```

This is because the untar does not use the specific path you are looking for:
```
Unarchiver
{'Input': {'archive_path': u'/Cache/local.munki.git-lfs/downloads/git-lfs-amd64-2.5.1.tar.gz',
           'destination_path': u'/Cache/local.munki.git-lfs/pkgroot/usr/local/bin',
           'purge_destination': True}}
```

Simple fix :)