### PR TITLE
Update OneDrive minimum OS version

### DIFF
--- a/MSOneDrive/MSOneDrive.munki.recipe
+++ b/MSOneDrive/MSOneDrive.munki.recipe
@@ -42,7 +42,7 @@
             <key>developer</key>
             <string>%MUNKI_DEVELOPER%</string>
             <key>minimum_os_version</key>
-            <string>10.9</string>
+            <string>10.12</string>
         </dict>
     </dict>
     <key>Process</key>


### PR DESCRIPTION
Microsoft OneDrive has required macOS 10.12+ since version 19.033.0218.0006 (March 12, 2019).

https://support.office.com/en-us/article/onedrive-release-notes-845dcf18-f921-435e-bf28-4e24b95e5fc0?ui=en-US&rs=en-US&ad=US#mac