### PR TITLE
Basic python3 compatibility

### DIFF
--- a/SharedProcessors/MSTeamsURLProvider.py
+++ b/SharedProcessors/MSTeamsURLProvider.py
@@ -65,7 +65,7 @@ class MSTeamsURLProvider(Processor):
             fref = urlopen(fetch_url)
             dl_url = fref.read()
             fref.close()
-        except BaseException as err:
+        except Exception as err:
             raise ProcessorError("Could not retrieve %s: %s" %(fetch_url, err))
         # if the URL is empty, raise error
         if not dl_url:

--- a/SharedProcessors/MSTeamsURLProvider.py
+++ b/SharedProcessors/MSTeamsURLProvider.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 """See docstring for MSTeamsURLProvider class"""
 #import re
+from __future__ import absolute_import
 import urllib2
 
 from autopkglib import Processor, ProcessorError

--- a/SharedProcessors/MSTeamsURLProvider.py
+++ b/SharedProcessors/MSTeamsURLProvider.py
@@ -17,9 +17,13 @@
 """See docstring for MSTeamsURLProvider class"""
 #import re
 from __future__ import absolute_import
-import urllib2
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.request import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["MSTeamsURLProvider"]
 
@@ -58,7 +62,7 @@ class MSTeamsURLProvider(Processor):
     def get_msteams_pkg_url(self, fetch_url):
         """Finds a download URL for latest MSTeams release"""
         try:
-            fref = urllib2.urlopen(fetch_url)
+            fref = urlopen(fetch_url)
             dl_url = fref.read()
             fref.close()
         except BaseException as err:


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.