### PR TITLE
Adjust PkgCreator arguments

### DIFF
--- a/Hugo/Hugo.pkg.recipe
+++ b/Hugo/Hugo.pkg.recipe
@@ -69,10 +69,10 @@
           <string>PkgCreator</string>
           <key>Arguments</key>
           <dict>
-            <key>pkgname</key>
-            <string>%NAME%_%KERNEL_BITS%bit-%version%</string>
             <key>pkg_request</key>
             <dict>
+              <key>pkgname</key>
+              <string>%NAME%_%KERNEL_BITS%bit-%version%</string>
               <key>pkgdir</key>
               <string>%RECIPE_CACHE_DIR%</string>
               <key>id</key>

--- a/LuLu/LuLu.pkg.recipe
+++ b/LuLu/LuLu.pkg.recipe
@@ -168,10 +168,10 @@ exit 0
           <string>PkgCreator</string>
           <key>Arguments</key>
           <dict>
-            <key>pkgname</key>
-            <string>%NAME%-%version%</string>
             <key>pkg_request</key>
             <dict>
+              <key>pkgname</key>
+              <string>%NAME%-%version%</string>
               <key>pkgroot</key>
               <string>%pkgroot%/build</string>
               <key>pkgdir</key>

--- a/Relay/Relay.pkg.recipe
+++ b/Relay/Relay.pkg.recipe
@@ -53,10 +53,10 @@
           <string>PkgCreator</string>
           <key>Arguments</key>
           <dict>
-            <key>pkgname</key>
-            <string>%NAME%-%version%</string>
             <key>pkg_request</key>
             <dict>
+              <key>pkgname</key>
+              <string>%NAME%-%version%</string>
               <key>pkgdir</key>
               <string>%RECIPE_CACHE_DIR%</string>
               <key>id</key>

--- a/SonarQubeScanner/SonarQubeScanner.pkg.recipe
+++ b/SonarQubeScanner/SonarQubeScanner.pkg.recipe
@@ -68,10 +68,10 @@
           <string>PkgCreator</string>
           <key>Arguments</key>
           <dict>
-            <key>pkgname</key>
-            <string>%NAME%</string>
             <key>pkg_request</key>
             <dict>
+              <key>pkgname</key>
+              <string>%NAME%</string>
               <key>pkgdir</key>
               <string>%RECIPE_CACHE_DIR%</string>
               <key>id</key>

--- a/VaporToolbox/VaporToolbox.pkg.recipe
+++ b/VaporToolbox/VaporToolbox.pkg.recipe
@@ -79,10 +79,10 @@
           <string>PkgCreator</string>
           <key>Arguments</key>
           <dict>
-            <key>pkgname</key>
-            <string>%NAME%</string>
             <key>pkg_request</key>
             <dict>
+              <key>pkgname</key>
+              <string>%NAME%</string>
               <key>pkgdir</key>
               <string>%RECIPE_CACHE_DIR%</string>
               <key>id</key>

--- a/faas-cli/faas-cli.pkg.recipe
+++ b/faas-cli/faas-cli.pkg.recipe
@@ -53,10 +53,10 @@
           <string>PkgCreator</string>
           <key>Arguments</key>
           <dict>
-            <key>pkgname</key>
-            <string>%NAME%-%version%</string>
             <key>pkg_request</key>
             <dict>
+              <key>pkgname</key>
+              <string>%NAME%-%version%</string>
               <key>pkgdir</key>
               <string>%RECIPE_CACHE_DIR%</string>
               <key>id</key>

--- a/git-lfs/git-lfs.pkg.recipe
+++ b/git-lfs/git-lfs.pkg.recipe
@@ -77,10 +77,10 @@
           <string>PkgCreator</string>
           <key>Arguments</key>
           <dict>
-            <key>pkgname</key>
-            <string>%NAME%-%BITS%-%version%</string>
             <key>pkg_request</key>
             <dict>
+              <key>pkgname</key>
+              <string>%NAME%-%BITS%-%version%</string>
               <key>pkgdir</key>
               <string>%RECIPE_CACHE_DIR%</string>
               <key>id</key>

--- a/kompose/kompose.pkg.recipe
+++ b/kompose/kompose.pkg.recipe
@@ -55,10 +55,10 @@
           <string>PkgCreator</string>
           <key>Arguments</key>
           <dict>
-            <key>pkgname</key>
-            <string>%NAME%</string>
             <key>pkg_request</key>
             <dict>
+              <key>pkgname</key>
+              <string>%NAME%</string>
               <key>pkgdir</key>
               <string>%RECIPE_CACHE_DIR%</string>
               <key>id</key>

--- a/minikube/minikube.pkg.recipe
+++ b/minikube/minikube.pkg.recipe
@@ -55,10 +55,10 @@
           <string>PkgCreator</string>
           <key>Arguments</key>
           <dict>
-            <key>pkgname</key>
-            <string>%NAME%</string>
             <key>pkg_request</key>
             <dict>
+              <key>pkgname</key>
+              <string>%NAME%</string>
               <key>pkgdir</key>
               <string>%RECIPE_CACHE_DIR%</string>
               <key>id</key>

--- a/saml2aws/saml2aws.pkg.recipe
+++ b/saml2aws/saml2aws.pkg.recipe
@@ -53,10 +53,10 @@
           <string>PkgCreator</string>
           <key>Arguments</key>
           <dict>
-            <key>pkgname</key>
-            <string>%NAME%-%version%</string>
             <key>pkg_request</key>
             <dict>
+              <key>pkgname</key>
+              <string>%NAME%-%version%</string>
               <key>pkgdir</key>
               <string>%RECIPE_CACHE_DIR%</string>
               <key>id</key>

--- a/terragrunt/terragrunt.pkg.recipe
+++ b/terragrunt/terragrunt.pkg.recipe
@@ -58,10 +58,10 @@
           <string>PkgCreator</string>
           <key>Arguments</key>
           <dict>
-            <key>pkgname</key>
-            <string>%NAME%-%version%</string>
             <key>pkg_request</key>
             <dict>
+              <key>pkgname</key>
+              <string>%NAME%-%version%</string>
               <key>pkgdir</key>
               <string>%RECIPE_CACHE_DIR%</string>
               <key>id</key>


### PR DESCRIPTION
`pkgname` is [intended](https://github.com/autopkg/autopkg/blob/e36d5cba2823dbdfcb69a41a38b1aef9fb76121c/Code/autopkgserver/autopkgserver#L47) to be in the `pkg_request` dictionary, not as a standalone argument for [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator).