### PR TITLE
Set minimum_os_version to 10.14

### DIFF
--- a/MSOneDrive/MSOneDrive.munki.recipe
+++ b/MSOneDrive/MSOneDrive.munki.recipe
@@ -42,7 +42,7 @@
             <key>developer</key>
             <string>%MUNKI_DEVELOPER%</string>
             <key>minimum_os_version</key>
-            <string>10.12</string>
+            <string>10.14</string>
         </dict>
     </dict>
     <key>Process</key>


### PR DESCRIPTION
According to [MS](https://support.microsoft.com/en-us/office/onedrive-system-requirements-cc0cb2b8-f446-445c-9b52-d3c2627d681e), the minimum_os_version is now 10.14.