### PR TITLE
Update git-lfs.pkg.recipe for new binary name

### DIFF
--- a/git-lfs/git-lfs.pkg.recipe
+++ b/git-lfs/git-lfs.pkg.recipe
@@ -56,7 +56,7 @@
           <key>Arguments</key>
           <dict>
             <key>source</key>
-            <string>%pkgroot%/usr/local/bin/%NAME%-%version%/%NAME%</string>
+            <string>%pkgroot%/usr/local/bin/%NAME%-%version%/%NAME%-%version%</string>
             <key>target</key>
             <string>%pkgroot%/usr/local/bin/%NAME%</string>
           </dict>


### PR DESCRIPTION
As of 3.2.0 it seems that LFS is packaging things with the version string appended. This PR updates the FileMover step to work with this change from upstream. 

Before change:
❯ autopkg run git-lfs.munki
Processing git-lfs.munki...
[Errno 2] No such file or directory: '/Users/rick.heil/Library/AutoPkg/Cache/local.munki.git-lfs/pkgroot/usr/local/bin/git-lfs-3.2.0/git-lfs' -> '/Users/rick.heil/Library/AutoPkg/Cache/local.munki.git-lfs/pkgroot/usr/local/bin/git-lfs'
Failed.

After change:
❯ autopkg run git-lfs.munki
Processing git-lfs.munki...

The following packages were built:
    Identifier          Version  Pkg Path
    ----------          -------  --------
    com.github.git-lfs  3.2.0    /Users/rick.heil/Library/AutoPkg/Cache/local.munki.git-lfs/git-lfs-amd64-3.2.0.pkg