### PR TITLE
Update MSTeams.munki.recipe

### DIFF
--- a/MSTeams/MSTeams.munki.recipe
+++ b/MSTeams/MSTeams.munki.recipe
@@ -3,15 +3,19 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads Microsoft Teams and imports it to Munki.</string>
+    <string>Downloads Microsoft Teams and imports it to Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.apettinen.munki.MSTeams</string>
     <key>ParentRecipe</key>
     <string>com.github.apettinen.download.MSTeams</string>
     <key>MinimumVersion</key>
-    <string>0.6.0</string>
+    <string>2.7</string>
     <key>Input</key>
     <dict>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>MUNKI_NAME</key>
         <string>%NAME%</string>
         <key>MUNKI_REPO_SUBDIR</key>
@@ -129,6 +133,8 @@
                 </array>
                 <key>version_comparison_key</key>
                 <string>%VERSIONTYPE%</string>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Hi, @apettinen 

The MSTeams Munki recipe currently doesn't set the `min_os_version` from the App's info.plist, and as such the default value of 10.5.0 is being set.

This PR adds in support for the new `derive_minimum_os_version` key in the `MunkiInstallsItemsCreator` processor. With this set the min_os_version becomes 10.11.0

This change requires AutoPkg version 2.7 or a higher, if compatibility with older versions of AutoPkg is needed, the same result can be achieved with something like below.

```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>info_path</key>
                <string>%RECIPE_CACHE_DIR%/Applications/APP_NAME.app</string>
                <key>plist_keys</key>
                <dict>
                    <key>LSMinimumSystemVersion</key>
                    <string>min_os_ver</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>PlistReader</string>
        </dict>
        <dict>
             <key>Arguments</key>
             <dict>
                <key>additional_pkginfo</key>
                <dict>
                    <key>minimum_os_version</key>
                    <string>%min_os_ver%</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>MunkiPkginfoMerger</string>
        </dict>
```

Output from a successful verbose run:

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/apettinen-recipes/MSTeams/MSTeams.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/apettinen-recipes/MSTeams/MSTeams.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/apettinen-recipes/MSTeams/MSTeams.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
com.github.apettinen.SharedProcessors/MSTeamsURLProvider
MSTeamsURLProvider: MSTeams URL found: https://statics.teams.cdn.office.net/production-osx/1.5.00.33356/Teams_osx.pkg
MSTeamsURLProvider: MSTeams version found: 1.5.00.33356
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 29 Nov 2022 20:42:26 GMT
URLDownloader: Storing new ETag header: "0x8DAD24A39C37704"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.apettinen.munki.MSTeams/downloads/MSTeams-1.5.00.33356.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "MSTeams-1.5.00.33356.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-11-29 19:50:16 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Microsoft Corporation (UBF8T346G9)
CodeSignatureVerifier:        Expires: 2023-05-16 04:46:41 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            6A 66 CD 33 B5 5B 9C 14 86 02 29 09 DB 7E 00 85 53 11 29 6B CE 11 
CodeSignatureVerifier:            9F 2A 93 5C 69 BF 56 3A 79 82
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.apettinen.munki.MSTeams/downloads/MSTeams-1.5.00.33356.pkg to /Users/paul/Library/AutoPkg/Cache/com.github.apettinen.munki.MSTeams/downloads/unpack
FileFinder
FileFinder: Found file match: '/Users/paul/Library/AutoPkg/Cache/com.github.apettinen.munki.MSTeams/downloads/unpack/Teams_osx_app.pkg' from globbed '/Users/paul/Library/AutoPkg/Cache/com.github.apettinen.munki.MSTeams/downloads/unpack/*Teams*.pkg'
FileFinder: Basename match: 'Teams_osx_app.pkg'
PkgRootCreator
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/com.github.apettinen.munki.MSTeams/downloads/Applications
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/com.github.apettinen.munki.MSTeams/downloads/Applications/Applications
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.apettinen.munki.MSTeams/downloads/unpack/Teams_osx_app.pkg/Payload to /Users/paul/Library/AutoPkg/Cache/com.github.apettinen.munki.MSTeams/downloads/Applications
Versioner
Versioner: Found version 1.00.533356 in file /Users/paul/Library/AutoPkg/Cache/com.github.apettinen.munki.MSTeams/downloads/Applications/Microsoft Teams.app/Contents/Info.plist
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '1.00.533356'} into pkginfo
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Microsoft Teams.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.11.0
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '1.00.533356', 'installs': [{'CFBundleIdentifier': 'com.microsoft.teams', 'CFBundleName': 'Microsoft Teams', 'CFBundleShortVersionString': '1.00.533356', 'CFBundleVersion': '533356', 'minosversion': '10.11.0', 'path': '/Applications/Microsoft Teams.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.11.0'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Office2019/MSTeams-1.00.533356.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Office2019/MSTeams-1.5.00.33356-1.00.533356.pkg
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.apettinen.munki.MSTeams/downloads/unpack
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.apettinen.munki.MSTeams/downloads/Applications
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.apettinen.munki.MSTeams/receipts/MSTeams.munki-receipt-20221220-123936.plist

The following new items were downloaded:
    Download Path                                                                                            
    -------------                                                                                            
    /Users/paul/Library/AutoPkg/Cache/com.github.apettinen.munki.MSTeams/downloads/MSTeams-1.5.00.33356.pkg  

The following new items were imported into Munki:
    Name     Version      Catalogs  Pkginfo Path                               Pkg Repo Path                                         Icon Repo Path  
    ----     -------      --------  ------------                               -------------                                         --------------  
    MSTeams  1.00.533356  testing   apps/Office2019/MSTeams-1.00.533356.plist  apps/Office2019/MSTeams-1.5.00.33356-1.00.533356.pkg 
```
