### PR TITLE
Update installs array for new MS Teams Classic

### DIFF
--- a/MSTeams/MSTeams.munki.recipe
+++ b/MSTeams/MSTeams.munki.recipe
@@ -99,7 +99,7 @@
             <key>Arguments</key>
             <dict>
                <key>input_plist_path</key>
-               <string>%RECIPE_CACHE_DIR%/downloads/Applications/Microsoft Teams.app/Contents/Info.plist</string>
+               <string>%RECIPE_CACHE_DIR%/downloads/Applications/Microsoft Teams Classic.app/Contents/Info.plist</string>
                <key>plist_version_key</key>
                <string>%VERSIONTYPE%</string>
             </dict>
@@ -125,7 +125,7 @@
                 <string>%RECIPE_CACHE_DIR%/downloads/</string>
                 <key>installs_item_paths</key>
                 <array>
-                    <string>/Applications/Microsoft Teams.app</string>
+                    <string>/Applications/Microsoft Teams Classic.app</string>
                 </array>
                 <key>version_comparison_key</key>
                 <string>%VERSIONTYPE%</string>


### PR DESCRIPTION
Updated recipe to create a installs array with correct info now that Microsoft has changed the name of the app