### PR TITLE
asset_regex update

### DIFF
--- a/LuLu/LuLu.download.recipe
+++ b/LuLu/LuLu.download.recipe
@@ -31,7 +31,7 @@
               <key>github_repo</key>
               <string>%GITHUB_REPO%</string>
               <key>asset_regex</key>
-              <string>LuLu_[\d+?]{1,}.|_[\d+?]{1,}.|_[\d+?]{1,}.dmg</string>
+              <string>LuLu_[\d+]\.[\d+]\.[\d+]\.dmg</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Following changes were made:
- Updated the asset_regex pattern of GitHubReleasesInfoProvider to match the .dmg name and thus to prevent CodeSignatureVerification error.